### PR TITLE
Accommodate admin directory name as per config setting

### DIFF
--- a/add.cfm
+++ b/add.cfm
@@ -32,7 +32,7 @@ StructAppend(request, form, "no");
 	<cfset translation.setRemoteID(request.remoteID)>
 	<cfset translation.save()>
 	<cfset pSession.setValue('showTab',true)>
-	<cflocation url="#application.configBean.getContext()#/admin/?muraAction=cArch.edit&contenthistid=#request.contentHistID#&siteid=#request.localSiteID#&contentid=#request.localID#&topid=#request.localID#&type=#request.type#&parentid=#request.parentID#&moduleid=00000000000000000000000000000000000"  addtoken="false">
+	<cflocation url="#application.configBean.getContext()##application.configBean.getAdminDir()#/?muraAction=cArch.edit&contenthistid=#request.contentHistID#&siteid=#request.localSiteID#&contentid=#request.localID#&topid=#request.localID#&type=#request.type#&parentid=#request.parentID#&moduleid=00000000000000000000000000000000000"  addtoken="false">
 
 <cfelse>
 	<cfif request.doAction eq "Create New Translation">
@@ -46,5 +46,5 @@ StructAppend(request, form, "no");
 	<cfset pSession.setValue('local',structCopy(request))>
 	<cfset pSession.setValue('showTab',false)>
 	<!--- go to newly create translation peer --->
-	<cflocation url="#application.configBean.getContext()#/admin/?muraAction=cArch.edit&contenthistid=#newBean.getContentHistID()#&siteid=#request.remoteSiteID#&contentid=#newBean.getContentID()#&&topid=#request.remoteID#&type=#request.type#&parentid=#request.remoteID#&moduleid=00000000000000000000000000000000000&doMap=true&suppressDraftNotice=true"  addtoken="false">
+	<cflocation url="#application.configBean.getContext()##application.configBean.getAdminDir()#/?muraAction=cArch.edit&contenthistid=#newBean.getContentHistID()#&siteid=#request.remoteSiteID#&contentid=#newBean.getContentID()#&&topid=#request.remoteID#&type=#request.type#&parentid=#request.remoteID#&moduleid=00000000000000000000000000000000000&doMap=true&suppressDraftNotice=true"  addtoken="false">
 </cfif>

--- a/assignmentTable.cfm
+++ b/assignmentTable.cfm
@@ -58,7 +58,7 @@ Associated Locales<cfif translationManager.hasTranslation(url.contentID,url.site
 		<cfif len(mapping.getRemoteID())>
 			<cfif application.permUtility.getModulePerm('00000000000000000000000000000000000',mapCrumb[1].siteID)
 				and listFindNoCase("Editor,Author",application.permUtility.getnodePerm(mapCrumb))>
-				<li class="edit"><a target="_top" href="#application.configBean.getContext()#/admin/index.cfm?muraaction=cArch.edit&contenthistid=#mapCrumb[1].contentHistID#&contentid=#mapCrumb[1].contentID#&type=#mapCrumb[1].type#&parentid=#mapCrumb[1].parentID#&topid=#mapCrumb[1].contentID#&siteid=#mapCrumb[1].siteID#&moduleid=00000000000000000000000000000000000&startrow=1" onclick=";"><i class="mi-pencil"></i>Edit</a></li>
+				<li class="edit"><a target="_top" href="#application.configBean.getContext()##application.configBean.getAdminDir()#/index.cfm?muraaction=cArch.edit&contenthistid=#mapCrumb[1].contentHistID#&contentid=#mapCrumb[1].contentID#&type=#mapCrumb[1].type#&parentid=#mapCrumb[1].parentID#&topid=#mapCrumb[1].contentID#&siteid=#mapCrumb[1].siteID#&moduleid=00000000000000000000000000000000000&startrow=1" onclick=";"><i class="mi-pencil"></i>Edit</a></li>
 			<cfelse>
 				<li class="edit editOff"><a>Edit</a></li>
 			</cfif>

--- a/cfcs/eventHandler.cfc
+++ b/cfcs/eventHandler.cfc
@@ -62,7 +62,7 @@
 						and contentBean.getSiteID() eq _local.remoteSiteID>
 
 					<cfif not len(event.getValue('returnURL'))>
-						<cfset returnURL="#application.configBean.getContext()#/admin/index.cfm?muraaction=cArch.edit&contenthistid=#_local.contentHistID#&siteid=#_local.localSiteID#&contentid=#_local.localID#&topid=#_local.localID#&type=#_local.type#&parentid=#_local.parentID#&moduleid=00000000000000000000000000000000000">		
+						<cfset returnURL="#application.configBean.getContext()##application.configBean.getAdminDir()#/index.cfm?muraaction=cArch.edit&contenthistid=#_local.contentHistID#&siteid=#_local.localSiteID#&contentid=#_local.localID#&topid=#_local.localID#&type=#_local.type#&parentid=#_local.parentID#&moduleid=00000000000000000000000000000000000">
 						<cfset request.event.setValue('returnURL',returnURL)/>
 					</cfif>
 

--- a/onContentEdit.cfm
+++ b/onContentEdit.cfm
@@ -45,7 +45,7 @@ function loadLocaleTable(activeTab){
 	var tab = activeTab;
 
 	try {
-		jQuery("##localeTableContainer").html('<br/><img src="/admin/assets/images/ajax-loader.gif">');
+		jQuery("##localeTableContainer").html('<br/><img src="#application.configBean.getAdminDir()#/assets/images/ajax-loader.gif">');
 	}
 	catch( any ) {
 	}

--- a/plugin/config.cfm
+++ b/plugin/config.cfm
@@ -30,7 +30,7 @@
 	
 	<cfif ( not (isdefined("secure") and not secure) or not $.currentUser().isLoggedIn() ) and isAdminRequest and not isUserInRole('S2')>
 		<cfif not structKeyExists(session,"siteID") or not application.permUtility.getModulePerm(pluginConfig.getValue('moduleID'), session.siteid)>
-			<cflocation url="#application.configBean.getContext()#/admin/" addtoken="false">
+			<cflocation url="#application.configBean.getContext()##application.configBean.getAdminDir()#/" addtoken="false">
 		</cfif>
 	</cfif>
 

--- a/search.cfm
+++ b/search.cfm
@@ -49,7 +49,7 @@
 <div class="mura-header">
   <h1>#pluginConfig.getName()#</h1>
     <div class="nav-module-specific btn-group">
-      <a class="btn" <cfif arrayLen(crumbdata) gt 30>href="##" onclick="history.go(-1);"<cfelse>href="#application.configBean.getContext()#/admin/index.cfm?muraaction=cArch.edit&contenthistid=#request.contentHistID#&siteid=#request.localSiteID#&contentid=#request.localID#&topid=#request.localID#&type=#request.type#&parentid=#request.parentID#&moduleid=00000000000000000000000000000000000##tabsysMuraTranslations"</cfif>><i class="mi-arrow-circle-left"></i>Return</a></li>   
+      <a class="btn" <cfif arrayLen(crumbdata) gt 30>href="##" onclick="history.go(-1);"<cfelse>href="#application.configBean.getContext()##application.configBean.getAdminDir()#/index.cfm?muraaction=cArch.edit&contenthistid=#request.contentHistID#&siteid=#request.localSiteID#&contentid=#request.localID#&topid=#request.localID#&type=#request.type#&parentid=#request.parentID#&moduleid=00000000000000000000000000000000000##tabsysMuraTranslations"</cfif>><i class="mi-arrow-circle-left"></i>Return</a></li>
     </div>
 </div>
 


### PR DESCRIPTION
Changed hard coded admin directory folder path to use getAdminDir() to accommodate naming as per configuration setting